### PR TITLE
Add automatic VCR boundary wrapper

### DIFF
--- a/doc/CONTEXT.md
+++ b/doc/CONTEXT.md
@@ -32,7 +32,7 @@
 ## ダミーアプリ（dummy/）
 - `MyFormComponent` は `count`/`last_updated_at` を持つ
 - `Increment/Decrement/Reset/UpdatedAt` を reducer で処理
-- `vcr_boundary` で境界を付与
+- コンポーネント境界は自動で `data-vcr-path` を付与
 - layout で `vcr_dispatch_script_tag` を挿入
 - Tailwind CDN で UI をリッチ化
 
@@ -43,6 +43,5 @@
 - `doc/tasks.md` に未解決タスク
 
 ## 既知の課題
-- `vcr_boundary` の自動化は未実装（手動）
 - 部分更新のDOM差し替えは最小JSで実装済み
 - テストはhelpers中心で拡充途中

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -3,10 +3,7 @@
 細かい直したいところ（メモ）
 
 ## 自動 vcr_boundary
-- コンポーネント境界は手書きではなく自動付与にしたい
-- 例: `ViewComponentReducible::Component` が `#call` の出力をラップ
-- 既存のテンプレに影響を出さない設計が必要
-- `data-vcr-path` と `data-vcr-root` の付与を標準化
+- `ViewComponentReducible::Component` で自動ラップ対応済み
 
 ## テスト拡充
 - `Runtime#render_target` の部分更新を仕様テストで担保

--- a/doc/usage_flow.md
+++ b/doc/usage_flow.md
@@ -39,15 +39,14 @@ end
 
 ## 3. Render state in the template
 
-Use the values defined in the state DSL.
+Use the values defined in the state DSL. The component output is automatically wrapped
+with a `data-vcr-path` boundary based on the envelope path.
 
 ```erb
-<%= helpers.vcr_boundary(path: vcr_envelope["path"]) do %>
-  <div>
-    <p>Name: <%= vcr_state["data"]["name"] %></p>
-    <p>Loading: <%= vcr_state["meta"]["loading"] %></p>
-  </div>
-<% end %>
+<div>
+  <p>Name: <%= vcr_state["data"]["name"] %></p>
+  <p>Loading: <%= vcr_state["meta"]["loading"] %></p>
+</div>
 ```
 
 ## 4. Trigger dispatch to the VCR endpoint

--- a/dummy/app/components/my_form_component.html.erb
+++ b/dummy/app/components/my_form_component.html.erb
@@ -1,44 +1,42 @@
-<%= helpers.vcr_boundary(path: vcr_envelope["path"]) do %>
-  <section class="min-h-[60vh] flex items-center justify-center bg-amber-50 text-slate-900">
-    <div class="w-full max-w-2xl rounded-3xl border border-amber-200 bg-gradient-to-br from-white via-amber-50 to-amber-100 p-8 shadow-2xl">
-      <div class="flex items-center justify-between">
-        <div>
-          <h1 class="text-4xl font-semibold tracking-tight">VCR Dummy</h1>
-          <p class="text-base text-amber-700">Minimal reducer flow with partial updates</p>
-        </div>
-        <span class="rounded-full border border-amber-200 bg-white/80 px-3 py-1 text-xs uppercase tracking-widest text-amber-700">
-          state
-        </span>
+<section class="min-h-[60vh] flex items-center justify-center bg-amber-50 text-slate-900">
+  <div class="w-full max-w-2xl rounded-3xl border border-amber-200 bg-gradient-to-br from-white via-amber-50 to-amber-100 p-8 shadow-2xl">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-4xl font-semibold tracking-tight">VCR Dummy</h1>
+        <p class="text-base text-amber-700">Minimal reducer flow with partial updates</p>
       </div>
+      <span class="rounded-full border border-amber-200 bg-white/80 px-3 py-1 text-xs uppercase tracking-widest text-amber-700">
+        state
+      </span>
+    </div>
 
-      <div class="mt-8 grid gap-6 md:grid-cols-2">
-        <div class="rounded-2xl border border-amber-200 bg-white/80 p-6">
-          <p class="text-xs uppercase tracking-widest text-amber-700">count</p>
-          <p class="mt-2 text-6xl font-bold text-amber-700"><%= vcr_state["data"]["count"] %></p>
-        </div>
-        <div class="rounded-2xl border border-amber-200 bg-white/80 p-6">
-          <p class="text-xs uppercase tracking-widest text-amber-700">last updated</p>
-          <p class="mt-2 text-base text-slate-800"><%= vcr_state["data"]["last_updated_at"] || "-" %></p>
-        </div>
+    <div class="mt-8 grid gap-6 md:grid-cols-2">
+      <div class="rounded-2xl border border-amber-200 bg-white/80 p-6">
+        <p class="text-xs uppercase tracking-widest text-amber-700">count</p>
+        <p class="mt-2 text-6xl font-bold text-amber-700"><%= vcr_state["data"]["count"] %></p>
       </div>
-
-      <div class="mt-8 flex flex-wrap gap-3">
-        <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Increment") do %>
-          <button type="submit" class="rounded-xl bg-amber-500 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-amber-500/30 hover:bg-amber-400">
-            +
-          </button>
-        <% end %>
-        <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Decrement") do %>
-          <button type="submit" class="rounded-xl bg-slate-200 px-6 py-3 text-base font-semibold text-slate-800 hover:bg-slate-300">
-            -
-          </button>
-        <% end %>
-        <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Reset") do %>
-          <button type="submit" class="rounded-xl border border-rose-300 bg-rose-100 px-6 py-3 text-base font-semibold text-rose-700 hover:bg-rose-200">
-            reset
-          </button>
-        <% end %>
+      <div class="rounded-2xl border border-amber-200 bg-white/80 p-6">
+        <p class="text-xs uppercase tracking-widest text-amber-700">last updated</p>
+        <p class="mt-2 text-base text-slate-800"><%= vcr_state["data"]["last_updated_at"] || "-" %></p>
       </div>
     </div>
-  </section>
-<% end %>
+
+    <div class="mt-8 flex flex-wrap gap-3">
+      <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Increment") do %>
+        <button type="submit" class="rounded-xl bg-amber-500 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-amber-500/30 hover:bg-amber-400">
+          +
+        </button>
+      <% end %>
+      <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Decrement") do %>
+        <button type="submit" class="rounded-xl bg-slate-200 px-6 py-3 text-base font-semibold text-slate-800 hover:bg-slate-300">
+          -
+        </button>
+      <% end %>
+      <%= helpers.vcr_dispatch_form(state: vcr_state_token, msg_type: "Reset") do %>
+        <button type="submit" class="rounded-xl border border-rose-300 bg-rose-100 px-6 py-3 text-base font-semibold text-rose-700 hover:bg-rose-200">
+          reset
+        </button>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/lib/view_component_reducible/component.rb
+++ b/lib/view_component_reducible/component.rb
@@ -43,6 +43,17 @@ module ViewComponentReducible
       "vcr:#{self.class.vcr_id}:#{path}"
     end
 
+    # Render component markup wrapped in a VCR boundary when available.
+    # @param view_context [ActionView::Base]
+    # @return [String]
+    def render_in(view_context, &block)
+      rendered = super
+      path = vcr_envelope && vcr_envelope["path"]
+      return rendered if path.nil? || path.to_s.empty?
+
+      view_context.content_tag(:div, rendered, data: { vcr_path: path })
+    end
+
     module ClassMethods
       # Stable component identifier for envelopes.
       # @return [String]

--- a/sig/view_component_reducible.rbs
+++ b/sig/view_component_reducible.rbs
@@ -19,6 +19,7 @@ module ViewComponentReducible
     def vcr_state_token: () -> String?
     def vcr_state: () -> Hash[String, Hash[String, untyped]]
     def vcr_dom_id: (path: String) -> String
+    def render_in: (ActionView::Base view_context) { () -> untyped } -> String
 
     module ClassMethods
       def vcr_id: () -> String

--- a/spec/view_component_reducible/component_spec.rb
+++ b/spec/view_component_reducible/component_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "action_view"
+require "view_component"
+
+RSpec.describe ViewComponentReducible::Component do
+  let(:view_context) { ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil) }
+
+  let(:component_class) do
+    Class.new(ViewComponent::Base) do
+      include ViewComponentReducible::Component
+
+      def call
+        "Hello"
+      end
+    end
+  end
+
+  it "wraps rendered output with a VCR boundary when a path is present" do
+    component = component_class.new(vcr_envelope: { "path" => "root/1" })
+
+    html = component.render_in(view_context)
+
+    expect(html).to include('data-vcr-path="root/1"')
+    expect(html).to include("Hello")
+  end
+
+  it "does not wrap output when no envelope is provided" do
+    component = component_class.new
+
+    html = component.render_in(view_context)
+
+    expect(html).not_to include("data-vcr-path")
+    expect(html).to include("Hello")
+  end
+end


### PR DESCRIPTION
### Motivation
- Remove the need to manually wrap component templates with `vcr_boundary` by applying boundaries automatically.
- Ensure components rendered by the mixin consistently expose a `data-vcr-path` for partial update flow.
- Keep templates cleaner while preserving the existing minimal-JS partial update design.

### Description
- Override `render_in` in `ViewComponentReducible::Component` to wrap rendered output with `data-vcr-path` when `vcr_envelope["path"]` is present. 
- Updated the RBS signature in `sig/view_component_reducible.rbs` to include the `render_in` method. 
- Removed manual `vcr_boundary` usage in the dummy template `dummy/app/components/my_form_component.html.erb` and updated docs `doc/usage_flow.md`, `doc/CONTEXT.md`, and `doc/tasks.md` to reflect automatic boundaries. 
- Added component unit tests in `spec/view_component_reducible/component_spec.rb` to assert boundary wrapping behavior. 

### Testing
- Added `spec/view_component_reducible/component_spec.rb` with two examples that verify output is wrapped when an envelope path exists and not wrapped otherwise. 
- No automated test suite was executed as part of this change. 
- (No other CI or runtime tests were run.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696375e2f4048331acbb2176ef15bbb4)