### PR TITLE
Pin Ruby/Bundler in CI, relax Bundler frozen mode, and add RuboCop config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1.4"
+          bundler: "2.6.9"
+
+      - name: Install gems
+        env:
+          BUNDLE_FROZEN: "false"
+          BUNDLE_DEPLOYMENT: "false"
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run RSpec
+        run: bundle exec rspec
+
+      - name: Install RuboCop
+        run: gem install rubocop -v "~> 1.59"
+
+      - name: Run RuboCop
+        run: rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: disable
+  Exclude:
+    - "dummy/**/*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+
+Layout/LineLength:
+  Max: 120
+
+Style/Documentation:
+  Enabled: false


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by Bundler's frozen lockfile mode when path gemspecs change by allowing the workflow to update/install gems.
- Ensure consistent Ruby and Bundler versions in CI by pinning them in the workflow to avoid environment drift.
- Provide a repository RuboCop configuration and run RuboCop in CI without requiring it to be in the project's `Gemfile.lock`.

### Description
- Add `.github/workflows/ci.yml` that pins `ruby-version: "3.1.4"` and `bundler: "2.6.9"` and checks out the repo before running tasks.
- Add an `Install gems` step that sets `BUNDLE_FROZEN` and `BUNDLE_DEPLOYMENT` to `false` and runs `bundle install --jobs 4 --retry 3` to avoid frozen lockfile errors.
- Install RuboCop in the workflow with `gem install rubocop -v "~> 1.59"` and run `rubocop`, and run tests with `bundle exec rspec` in CI.
- Add `.rubocop.yml` with `TargetRubyVersion: 3.1`, `NewCops: disable`, excludes for `dummy/`, `vendor/`, and `node_modules/`, and some style overrides.

### Testing
- No automated tests were executed locally as part of this change.
- The GitHub Actions workflow will run `bundle exec rspec` and `rubocop` on `push` and `pull_request` events to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963742ce4ac8331976c86a800270208)