### PR TITLE
Add `all` mise task to run specs, e2e, and lint

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -13,3 +13,7 @@ run = "bundle exec rspec"
 [tasks.lint]
 description = "Run Rubocop"
 run = "bundle exec rubocop -A"
+
+[tasks.all]
+description = "Run RSpec, Playwright E2E, and Rubocop"
+run = "bundle exec rspec && npm run test:e2e && bundle exec rubocop -A"


### PR DESCRIPTION
### Motivation
- Provide a single `mise` task that runs the project's unit tests, Playwright E2E tests, and RuboCop linting.
- Simplify local CI-like checks by combining existing commands into one task. 

### Description
- Added a `[tasks.all]` entry to `.mise.toml` with the description "Run RSpec, Playwright E2E, and Rubocop".
- The new task runs `bundle exec rspec && npm run test:e2e && bundle exec rubocop -A` to execute specs, e2e tests, and linting in sequence.

### Testing
- No automated tests were executed because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69644e38909083319fffe6cb53abcf16)