### PR TITLE
Split state param name by adapter

### DIFF
--- a/lib/view_component_reducible/adapter/base.rb
+++ b/lib/view_component_reducible/adapter/base.rb
@@ -4,6 +4,11 @@ module ViewComponentReducible
   module Adapter
     # Base adapter interface for envelope serialization.
     class Base
+      # @return [String]
+      def self.state_param_name
+        'vcr_state'
+      end
+
       # @param secret [String]
       # @param _kwargs [Hash]
       def initialize(secret:, **_kwargs)

--- a/lib/view_component_reducible/adapter/hidden_field.rb
+++ b/lib/view_component_reducible/adapter/hidden_field.rb
@@ -23,7 +23,7 @@ module ViewComponentReducible
       # @param request [ActionDispatch::Request]
       # @return [Hash]
       def load(request:)
-        signed = request.params.fetch('vcr_state')
+        signed = request.params.fetch(self.class.state_param_name)
         verifier.verify(signed)
       end
     end

--- a/lib/view_component_reducible/adapter/redis.rb
+++ b/lib/view_component_reducible/adapter/redis.rb
@@ -12,6 +12,10 @@ module ViewComponentReducible
       DEFAULT_TTL = 900
       DEFAULT_NAMESPACE = 'vcr'
 
+      def self.state_param_name
+        'vcr_state_key'
+      end
+
       # @param secret [String]
       # @param redis [Object, nil]
       # @param redis_url [String, nil]
@@ -42,7 +46,7 @@ module ViewComponentReducible
       # @param request [ActionDispatch::Request]
       # @return [Hash]
       def load(request:)
-        signed = request.params.fetch('vcr_state')
+        signed = request.params.fetch(self.class.state_param_name)
         payload = verifier.verify(signed)
         key = payload.fetch('k')
         raw = @redis.get(redis_key(key))

--- a/lib/view_component_reducible/adapter/session.rb
+++ b/lib/view_component_reducible/adapter/session.rb
@@ -8,6 +8,10 @@ module ViewComponentReducible
   module Adapter
     # Session adapter storing envelope in server session.
     class Session < Base
+      def self.state_param_name
+        'vcr_state_key'
+      end
+
       # @return [ActiveSupport::MessageVerifier]
       def verifier
         @verifier ||= ActiveSupport::MessageVerifier.new(@secret, digest: 'SHA256', serializer: JSON)
@@ -28,7 +32,7 @@ module ViewComponentReducible
       # @param request [ActionDispatch::Request]
       # @return [Hash]
       def load(request:)
-        signed = request.params.fetch('vcr_state')
+        signed = request.params.fetch(self.class.state_param_name)
         payload = verifier.verify(signed)
         key = payload.fetch('k')
         request.session.fetch("vcr:#{key}")

--- a/lib/view_component_reducible/helpers.rb
+++ b/lib/view_component_reducible/helpers.rb
@@ -24,10 +24,11 @@ module ViewComponentReducible
     def vcr_dispatch_form(state:, msg_type:, msg_payload: {}, target_path: nil, url: '/vcr/dispatch', &block)
       payload = msg_payload.is_a?(String) ? msg_payload : JSON.generate(msg_payload)
       resolved_target = target_path || vcr_envelope_path || instance_variable_get(:@vcr_current_path) || 'root'
+      state_param = ViewComponentReducible.config.adapter.state_param_name
 
-      form_tag(url, method: :post, data: { vcr_form: true }) do
+      form_tag(url, method: :post, data: { vcr_form: true, vcr_state_param: state_param }) do
         body = [
-          hidden_field_tag('vcr_state', state),
+          hidden_field_tag(state_param, state),
           hidden_field_tag('vcr_msg_type', msg_type),
           hidden_field_tag('vcr_msg_payload', payload),
           hidden_field_tag('vcr_target_path', resolved_target),
@@ -74,7 +75,8 @@ module ViewComponentReducible
                 if (payload.state) {
                   var boundary = document.querySelector('[data-vcr-path="' + targetPath + '"]');
                   if (boundary) {
-                    boundary.querySelectorAll('input[name="vcr_state"]').forEach(function(input) {
+                    var stateParam = form.dataset.vcrStateParam || "vcr_state";
+                    boundary.querySelectorAll('input[name="' + stateParam + '"]').forEach(function(input) {
                       input.value = payload.state;
                     });
                   }

--- a/sig/view_component_reducible.rbs
+++ b/sig/view_component_reducible.rbs
@@ -39,6 +39,7 @@ module ViewComponentReducible
 
   module Adapter
     class Base
+      def self.state_param_name: () -> String
       def initialize: (secret: String, **untyped) -> void
       def dump: (Hash[untyped, untyped] envelope, request: ActionDispatch::Request) -> String
       def load: (request: ActionDispatch::Request) -> Hash[untyped, untyped]

--- a/spec/view_component_reducible/adapter/redis_spec.rb
+++ b/spec/view_component_reducible/adapter/redis_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ViewComponentReducible::Adapter::Redis do
     request = Struct.new(:params).new({})
 
     signed = adapter.dump(envelope, request: request)
-    request.params['vcr_state'] = signed
+    request.params['vcr_state_key'] = signed
 
     expect(adapter.load(request: request)).to eq(envelope)
   end

--- a/spec/view_component_reducible/adapter/session_spec.rb
+++ b/spec/view_component_reducible/adapter/session_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ViewComponentReducible::Adapter::Session do
     request = Struct.new(:params, :session).new({}, {})
 
     signed = adapter.dump(envelope, request: request)
-    request.params['vcr_state'] = signed
+    request.params['vcr_state_key'] = signed
 
     expect(adapter.load(request: request)).to eq(envelope)
   end

--- a/spec/view_component_reducible/helpers_spec.rb
+++ b/spec/view_component_reducible/helpers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ViewComponentReducible::Helpers do
       target_path: 'root/1'
     ) { 'Go' }
 
-    expect(html).to include('name="vcr_state"')
+    expect(html).to include(%(name="#{ViewComponentReducible.config.adapter.state_param_name}"))
     expect(html).to include('value="token"')
     expect(html).to include('name="vcr_msg_type"')
     expect(html).to include('value="Ping"')


### PR DESCRIPTION
## Summary\n- use adapter-specific state param names (hidden_field: vcr_state, session/redis: vcr_state_key)\n- update helpers and JS to respect adapter param name\n- adjust adapter tests for new param name\n\n## Testing\n- mise run all